### PR TITLE
ulcb: Show a message if the mac address isn't set

### DIFF
--- a/board/renesas/ulcb/ulcb.c
+++ b/board/renesas/ulcb/ulcb.c
@@ -189,8 +189,10 @@ int board_eth_init(bd_t *bis)
 	u32 val;
 	unsigned char enetaddr[6];
 
-	if (!eth_getenv_enetaddr("ethaddr", enetaddr))
+	if (!eth_getenv_enetaddr("ethaddr", enetaddr)) {
+		printf("<ethaddr> not configured\n");
 		return ret;
+	}
 
 	/* Set Mac address */
 	val = enetaddr[0] << 24 | enetaddr[1] << 16 |


### PR DESCRIPTION
I just spent some time scratching my head why the ethernet
initialisation failed on an ULCB board until i discovered this was
simply due to a missing mac address setting. Print a message in that
case to make it more obvious that this could be the issue.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>
--
I'm not sure what the development branch in the repository is hence pushing against the latest release, please let me know if you prefer PR against another branch.