### PR TITLE
V2015.04/rcar 3.5.0 distro configuration

### DIFF
--- a/common/cmd_pxe.c
+++ b/common/cmd_pxe.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <linux/list.h>
 #include <fs.h>
+#include <asm/io.h>
 
 #include "menu.h"
 #include "cli.h"
@@ -188,11 +189,12 @@ static int do_get_any(cmd_tbl_t *cmdtp, const char *file_path, char *file_addr)
  *
  * Returns 1 for success, or < 0 on error.
  */
-static int get_relfile(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr)
+static int get_relfile(cmd_tbl_t *cmdtp, const char *file_path,
+	unsigned long file_addr)
 {
 	size_t path_len;
 	char relfile[MAX_TFTP_PATH_LEN+1];
-	char addr_buf[10];
+	char addr_buf[18];
 	int err;
 
 	err = get_bootfile_path(file_path, relfile, sizeof(relfile));
@@ -215,7 +217,7 @@ static int get_relfile(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr)
 
 	printf("Retrieving file: %s\n", relfile);
 
-	sprintf(addr_buf, "%p", file_addr);
+	sprintf(addr_buf, "%lx", file_addr);
 
 	return do_getfile(cmdtp, relfile, addr_buf);
 }
@@ -227,11 +229,13 @@ static int get_relfile(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr)
  *
  * Returns 1 on success, or < 0 for error.
  */
-static int get_pxe_file(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr)
+static int get_pxe_file(cmd_tbl_t *cmdtp, const char *file_path,
+	unsigned long file_addr)
 {
 	unsigned long config_file_size;
 	char *tftp_filesize;
 	int err;
+	char *buf;
 
 	err = get_relfile(cmdtp, file_path, file_addr);
 
@@ -250,7 +254,9 @@ static int get_pxe_file(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr
 	if (strict_strtoul(tftp_filesize, 16, &config_file_size) < 0)
 		return -EINVAL;
 
-	*(char *)(file_addr + config_file_size) = '\0';
+	buf = map_sysmem(file_addr + config_file_size, 1);
+	*buf = '\0';
+	unmap_sysmem(buf);
 
 	return 1;
 }
@@ -266,7 +272,8 @@ static int get_pxe_file(cmd_tbl_t *cmdtp, const char *file_path, void *file_addr
  *
  * Returns 1 on success or < 0 on error.
  */
-static int get_pxelinux_path(cmd_tbl_t *cmdtp, const char *file, void *pxefile_addr_r)
+static int get_pxelinux_path(cmd_tbl_t *cmdtp, const char *file,
+	unsigned long pxefile_addr_r)
 {
 	size_t base_len = strlen(PXELINUX_DIR);
 	char path[MAX_TFTP_PATH_LEN+1];
@@ -287,7 +294,7 @@ static int get_pxelinux_path(cmd_tbl_t *cmdtp, const char *file, void *pxefile_a
  *
  * Returns 1 on success or < 0 on error.
  */
-static int pxe_uuid_path(cmd_tbl_t *cmdtp, void *pxefile_addr_r)
+static int pxe_uuid_path(cmd_tbl_t *cmdtp, unsigned long pxefile_addr_r)
 {
 	char *uuid_str;
 
@@ -305,7 +312,7 @@ static int pxe_uuid_path(cmd_tbl_t *cmdtp, void *pxefile_addr_r)
  *
  * Returns 1 on success or < 0 on error.
  */
-static int pxe_mac_path(cmd_tbl_t *cmdtp, void *pxefile_addr_r)
+static int pxe_mac_path(cmd_tbl_t *cmdtp, unsigned long pxefile_addr_r)
 {
 	char mac_str[21];
 	int err;
@@ -325,7 +332,7 @@ static int pxe_mac_path(cmd_tbl_t *cmdtp, void *pxefile_addr_r)
  *
  * Returns 1 on success or < 0 on error.
  */
-static int pxe_ipaddr_paths(cmd_tbl_t *cmdtp, void *pxefile_addr_r)
+static int pxe_ipaddr_paths(cmd_tbl_t *cmdtp, unsigned long pxefile_addr_r)
 {
 	char ip_addr[9];
 	int mask_pos, err;
@@ -384,9 +391,9 @@ do_pxe_get(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 	 * Keep trying paths until we successfully get a file we're looking
 	 * for.
 	 */
-	if (pxe_uuid_path(cmdtp, (void *)pxefile_addr_r) > 0 ||
-	    pxe_mac_path(cmdtp, (void *)pxefile_addr_r) > 0 ||
-	    pxe_ipaddr_paths(cmdtp, (void *)pxefile_addr_r) > 0) {
+	if (pxe_uuid_path(cmdtp, pxefile_addr_r) > 0 ||
+	    pxe_mac_path(cmdtp, pxefile_addr_r) > 0 ||
+	    pxe_ipaddr_paths(cmdtp, pxefile_addr_r) > 0) {
 		printf("Config file found\n");
 
 		return 0;
@@ -394,7 +401,7 @@ do_pxe_get(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 
 	while (pxe_default_paths[i]) {
 		if (get_pxelinux_path(cmdtp, pxe_default_paths[i],
-				      (void *)pxefile_addr_r) > 0) {
+				      pxefile_addr_r) > 0) {
 			printf("Config file found\n");
 			return 0;
 		}
@@ -427,7 +434,7 @@ static int get_relfile_envaddr(cmd_tbl_t *cmdtp, const char *file_path, const ch
 	if (strict_strtoul(envaddr, 16, &file_addr) < 0)
 		return -EINVAL;
 
-	return get_relfile(cmdtp, file_path, (void *)file_addr);
+	return get_relfile(cmdtp, file_path, file_addr);
 }
 
 /*
@@ -790,6 +797,7 @@ static int label_boot(cmd_tbl_t *cmdtp, struct pxe_label *label)
 	else
 		do_bootz(cmdtp, 0, bootm_argc, bootm_argv);
 #endif
+	unmap_sysmem(buf);
 	return 1;
 }
 
@@ -1054,7 +1062,8 @@ static int parse_integer(char **c, int *dst)
 	return 1;
 }
 
-static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, struct pxe_menu *cfg, int nest_level);
+static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, unsigned long base,
+	struct pxe_menu *cfg, int nest_level);
 
 /*
  * Parse an include statement, and retrieve and parse the file it mentions.
@@ -1064,12 +1073,14 @@ static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, struct pxe_menu *cfg, in
  * include, nest_level has already been incremented and doesn't need to be
  * incremented here.
  */
-static int handle_include(cmd_tbl_t *cmdtp, char **c, char *base,
+static int handle_include(cmd_tbl_t *cmdtp, char **c, unsigned long base,
 				struct pxe_menu *cfg, int nest_level)
 {
 	char *include_path;
 	char *s = *c;
 	int err;
+	char *buf;
+	int ret;
 
 	err = parse_sliteral(c, &include_path);
 
@@ -1086,20 +1097,25 @@ static int handle_include(cmd_tbl_t *cmdtp, char **c, char *base,
 		return err;
 	}
 
-	return parse_pxefile_top(cmdtp, base, cfg, nest_level);
+	buf = map_sysmem(base, 0);
+	ret = parse_pxefile_top(cmdtp, buf, base, cfg, nest_level);
+	unmap_sysmem(buf);
+
+	return ret;
 }
 
 /*
  * Parse lines that begin with 'menu'.
  *
- * b and nest are provided to handle the 'menu include' case.
+ * base and nest are provided to handle the 'menu include' case.
  *
- * b should be the address where the file currently being parsed is stored.
+ * base should point to a location where it's safe to store the included file.
  *
  * nest_level should be 1 when parsing the top level pxe file, 2 when parsing
  * a file it includes, 3 when parsing a file included by that file, and so on.
  */
-static int parse_menu(cmd_tbl_t *cmdtp, char **c, struct pxe_menu *cfg, char *b, int nest_level)
+static int parse_menu(cmd_tbl_t *cmdtp, char **c, struct pxe_menu *cfg,
+				unsigned long base, int nest_level)
 {
 	struct token t;
 	char *s = *c;
@@ -1114,7 +1130,7 @@ static int parse_menu(cmd_tbl_t *cmdtp, char **c, struct pxe_menu *cfg, char *b,
 		break;
 
 	case T_INCLUDE:
-		err = handle_include(cmdtp, c, b + strlen(b) + 1, cfg,
+		err = handle_include(cmdtp, c, base, cfg,
 						nest_level + 1);
 		break;
 
@@ -1281,7 +1297,8 @@ static int parse_label(char **c, struct pxe_menu *cfg)
  *
  * Returns 1 on success, < 0 on error.
  */
-static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, struct pxe_menu *cfg, int nest_level)
+static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, unsigned long base,
+				struct pxe_menu *cfg, int nest_level)
 {
 	struct token t;
 	char *s, *b, *label_name;
@@ -1303,7 +1320,9 @@ static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, struct pxe_menu *cfg, in
 		switch (t.type) {
 		case T_MENU:
 			cfg->prompt = 1;
-			err = parse_menu(cmdtp, &p, cfg, b, nest_level);
+			err = parse_menu(cmdtp, &p, cfg,
+				base + ALIGN(strlen(b) + 1, 4),
+				nest_level);
 			break;
 
 		case T_TIMEOUT:
@@ -1328,8 +1347,9 @@ static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, struct pxe_menu *cfg, in
 			break;
 
 		case T_INCLUDE:
-			err = handle_include(cmdtp, &p, b + ALIGN(strlen(b), 4), cfg,
-							nest_level + 1);
+			err = handle_include(cmdtp, &p,
+				base + ALIGN(strlen(b), 4), cfg,
+				nest_level + 1);
 			break;
 
 		case T_PROMPT:
@@ -1385,9 +1405,11 @@ static void destroy_pxe_menu(struct pxe_menu *cfg)
  * files it includes). The resulting pxe_menu struct can be free()'d by using
  * the destroy_pxe_menu() function.
  */
-static struct pxe_menu *parse_pxefile(cmd_tbl_t *cmdtp, char *menucfg)
+static struct pxe_menu *parse_pxefile(cmd_tbl_t *cmdtp, unsigned long menucfg)
 {
 	struct pxe_menu *cfg;
+	char *buf;
+	int r;
 
 	cfg = malloc(sizeof(struct pxe_menu));
 
@@ -1398,7 +1420,11 @@ static struct pxe_menu *parse_pxefile(cmd_tbl_t *cmdtp, char *menucfg)
 
 	INIT_LIST_HEAD(&cfg->labels);
 
-	if (parse_pxefile_top(cmdtp, menucfg, cfg, 1) < 0) {
+	buf = map_sysmem(menucfg, 0);
+	r = parse_pxefile_top(cmdtp, buf, menucfg, cfg, 1);
+	unmap_sysmem(buf);
+
+	if (r < 0) {
 		destroy_pxe_menu(cfg);
 		return NULL;
 	}
@@ -1556,7 +1582,7 @@ do_pxe_boot(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 		return 1;
 	}
 
-	cfg = parse_pxefile(cmdtp, (char *)(pxefile_addr_r));
+	cfg = parse_pxefile(cmdtp, pxefile_addr_r);
 
 	if (cfg == NULL) {
 		printf("Error parsing config file\n");
@@ -1663,12 +1689,12 @@ static int do_sysboot(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 		return 1;
 	}
 
-	if (get_pxe_file(cmdtp, filename, (void *)pxefile_addr_r) < 0) {
+	if (get_pxe_file(cmdtp, filename, pxefile_addr_r) < 0) {
 		printf("Error reading config file\n");
 		return 1;
 	}
 
-	cfg = parse_pxefile(cmdtp, (char *)(pxefile_addr_r));
+	cfg = parse_pxefile(cmdtp, pxefile_addr_r);
 
 	if (cfg == NULL) {
 		printf("Error parsing config file\n");

--- a/common/cmd_pxe.c
+++ b/common/cmd_pxe.c
@@ -792,8 +792,12 @@ static int label_boot(cmd_tbl_t *cmdtp, struct pxe_label *label)
 	/* Try bootm for legacy and FIT format image */
 	if (genimg_get_format(buf) != IMAGE_FORMAT_INVALID)
 		do_bootm(cmdtp, 0, bootm_argc, bootm_argv);
-#ifdef CONFIG_CMD_BOOTZ
-	/* Try booting a zImage */
+#ifdef CONFIG_CMD_BOOTI
+	/* Try booting an AArch64 Linux kernel image */
+	else
+		do_booti(cmdtp, 0, bootm_argc, bootm_argv);
+#elif defined(CONFIG_CMD_BOOTZ)
+	/* Try booting a Image */
 	else
 		do_bootz(cmdtp, 0, bootm_argc, bootm_argv);
 #endif

--- a/include/command.h
+++ b/include/command.h
@@ -104,6 +104,8 @@ static inline int bootm_maybe_autostart(cmd_tbl_t *cmdtp, const char *cmd)
 
 extern int do_bootz(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[]);
 
+extern int do_booti(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[]);
+
 extern int common_diskboot(cmd_tbl_t *cmdtp, const char *intf, int argc,
 			   char *const argv[]);
 

--- a/include/configs/h3ulcb.h
+++ b/include/configs/h3ulcb.h
@@ -104,17 +104,12 @@
 #define CONFIG_ENV_SIZE		(CONFIG_ENV_SECT_SIZE)
 #define CONFIG_ENV_SIZE_REDUND	(CONFIG_ENV_SIZE)
 
+/* Use the default distribution boot commands */
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"fdt_high=0xffffffffffffffff\0" \
-	"initrd_high=0xffffffffffffffff\0"
+	"fdtfile=renesas/r8a7796-h3ulcb.dtb\0" \
+	ENV_MEM_LAYOUT_SETTINGS \
+	BOOTENV
 
-#define CONFIG_BOOTARGS \
-	"root=/dev/nfs rw " \
-	"nfsroot=192.168.0.1:/export/rfs ip=192.168.0.20"
-
-#define CONFIG_BOOTCOMMAND \
-	"tftp 0x48080000 Image; " \
-	"tftp 0x48000000 Image-r8a7795-h3ulcb.dtb; " \
-	"booti 0x48080000 - 0x48000000"
+#include <config_distro_bootcmd.h>
 
 #endif /* __H3ULCB_H */

--- a/include/configs/m3ulcb.h
+++ b/include/configs/m3ulcb.h
@@ -111,17 +111,12 @@
 #define CONFIG_ENV_SIZE		(CONFIG_ENV_SECT_SIZE)
 #define CONFIG_ENV_SIZE_REDUND	(CONFIG_ENV_SIZE)
 
+/* Use the default distribution boot commands */
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"fdt_high=0xffffffffffffffff\0" \
-	"initrd_high=0xffffffffffffffff\0"
+	"fdtfile=renesas/r8a7796-m3ulcb.dtb\0" \
+	ENV_MEM_LAYOUT_SETTINGS \
+	BOOTENV
 
-#define CONFIG_BOOTARGS \
-	"root=/dev/nfs rw " \
-	"nfsroot=192.168.0.1:/export/rfs ip=192.168.0.20"
-
-#define CONFIG_BOOTCOMMAND \
-	"tftp 0x48080000 Image; " \
-	"tftp 0x48000000 Image-r8a7796-m3ulcb.dtb; " \
-	"booti 0x48080000 - 0x48000000"
+#include <config_distro_bootcmd.h>
 
 #endif /* __M3ULCB_H */

--- a/include/configs/r8a7795_salvator-x.h
+++ b/include/configs/r8a7795_salvator-x.h
@@ -108,17 +108,12 @@
 #define CONFIG_ENV_SIZE         (CONFIG_ENV_SECT_SIZE)
 #define CONFIG_ENV_SIZE_REDUND  (CONFIG_ENV_SIZE)
 
-#define CONFIG_EXTRA_ENV_SETTINGS       \
-	"fdt_high=0xffffffffffffffff\0" \
-	"initrd_high=0xffffffffffffffff\0"
+/* Use the default distribution boot commands */
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	"fdtfile=renesas/r8a7795-salvator-x.dtb\0" \
+	ENV_MEM_LAYOUT_SETTINGS \
+	BOOTENV
 
-#define CONFIG_BOOTARGS \
-	"root=/dev/nfs rw "     \
-	"nfsroot=192.168.0.1:/export/rfs ip=192.168.0.20"
-
-#define CONFIG_BOOTCOMMAND      \
-	"tftp 0x48080000 Image; " \
-	"tftp 0x48000000 Image-r8a7795-salvator-x.dtb; " \
-	"booti 0x48080000 - 0x48000000"
+#include <config_distro_bootcmd.h>
 
 #endif /* __SALVATOR_X_H */

--- a/include/configs/r8a7796_salvator-x.h
+++ b/include/configs/r8a7796_salvator-x.h
@@ -108,17 +108,12 @@
 #define CONFIG_ENV_SIZE         (CONFIG_ENV_SECT_SIZE)
 #define CONFIG_ENV_SIZE_REDUND  (CONFIG_ENV_SIZE)
 
-#define CONFIG_EXTRA_ENV_SETTINGS       \
-	"fdt_high=0xffffffffffffffff\0" \
-	"initrd_high=0xffffffffffffffff\0"
+/* Use the default distribution boot commands */
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	"fdtfile=renesas/r8a7796-salvator-x.dtb\0" \
+	ENV_MEM_LAYOUT_SETTINGS \
+	BOOTENV
 
-#define CONFIG_BOOTARGS \
-	"root=/dev/nfs rw "     \
-	"nfsroot=192.168.0.1:/export/rfs ip=192.168.0.20"
-
-#define CONFIG_BOOTCOMMAND      \
-	"tftp 0x48080000 Image; " \
-	"tftp 0x48000000 Image-r8a7796-salvator-x.dtb; " \
-	"booti 0x48080000 - 0x48000000"
+#include <config_distro_bootcmd.h>
 
 #endif /* __SALVATOR_X_H */

--- a/include/configs/rcar-gen3-common.h
+++ b/include/configs/rcar-gen3-common.h
@@ -99,4 +99,21 @@
 #define CONFIG_SYS_MALLOC_LEN		(1 * 1024 * 1024)
 #define CONFIG_SYS_BOOTMAPSZ		(8 * 1024 * 1024)
 
+#define ENV_MEM_LAYOUT_SETTINGS \
+	"fdt_high=0xffffffffffffffff\0" \
+	"initrd_high=0xffffffffffffffff\0" \
+	"fdt_addr_r=0x48000000\0" \
+	"pxefile_addr_r=0x48000000\0" \
+	"kernel_addr_r=0x48080000\0" \
+	"scriptaddr=0x49000000\0" \
+	"ramdisk_addr_r=0x49100000\0" \
+
+/* Default boot targets, SD first, then eMMC, USB and network */
+#define BOOT_TARGET_DEVICES(func) \
+	func(MMC, mmc, 0) \
+	func(MMC, mmc, 1) \
+	func(USB, usb, 0) \
+	func(PXE, pxe, na) \
+	func(DHCP, dhcp, na)
+
 #endif	/* __RCAR_GEN3_COMMON_H */

--- a/include/configs/rcar-gen3-common.h
+++ b/include/configs/rcar-gen3-common.h
@@ -11,25 +11,15 @@
 #define __RCAR_GEN3_COMMON_H
 
 #include <asm/arch/rcar_gen3.h>
+#include <config_distro_defaults.h>
 
-#define CONFIG_CMD_BOOTI
-#define CONFIG_CMD_EDITENV
-#define CONFIG_CMD_SAVEENV
-#define CONFIG_CMD_MEMORY
+/* Flash not used from u-boot */
+#define CONFIG_SYS_NO_FLASH
+#include <config_cmd_default.h>
+
 #define CONFIG_CMD_DFL
 #define CONFIG_CMD_SDRAM
-#define CONFIG_CMD_RUN
-#define CONFIG_CMD_LOADS
-#define CONFIG_CMD_NET
-#define CONFIG_CMD_MII
-#define CONFIG_CMD_PING
-#define CONFIG_CMD_DHCP
-#define CONFIG_CMD_NFS
-#define CONFIG_CMD_BOOTZ
 #define CONFIG_CMD_USB
-#define CONFIG_CMD_FAT
-#define CONFIG_CMD_EXT2
-#define CONFIG_CMD_EXT4
 #define CONFIG_CMD_EXT4_WRITE
 
 #define CONFIG_SYS_THUMB_BUILD
@@ -37,24 +27,15 @@
 
 #define CONFIG_REMAKE_ELF
 
-/* boot option */
-#define CONFIG_SUPPORT_RAW_INITRD
-
 /* Support File sytems */
 #define CONFIG_FAT_WRITE
-#define CONFIG_DOS_PARTITION
-#define CONFIG_SUPPORT_VFAT
-#define CONFIG_FS_EXT4
 #define CONFIG_EXT4_WRITE
 
 #define CONFIG_CMDLINE_TAG
 #define CONFIG_SETUP_MEMORY_TAGS
 #define CONFIG_INITRD_TAG
-#define CONFIG_CMDLINE_EDITING
-#define CONFIG_OF_LIBFDT
 
 #define CONFIG_BAUDRATE		115200
-#define CONFIG_BOOTDELAY	3
 
 #define CONFIG_VERSION_VARIABLE
 #undef	CONFIG_SHOW_BOOT_PROGRESS
@@ -72,7 +53,6 @@
 #undef  CONFIG_SYS_CONSOLE_OVERWRITE_ROUTINE
 #undef  CONFIG_SYS_CONSOLE_ENV_OVERWRITE
 
-#define CONFIG_SYS_LONGHELP
 #define CONFIG_SYS_CBSIZE		256
 #define CONFIG_SYS_PBSIZE		256
 #define CONFIG_SYS_MAXARGS		16


### PR DESCRIPTION
The default u-boot configuration for r-car gen3 device is a bit specific (e.g. standard bootargs specify an nfs server by ip and the bootcmd does tftp). U-boot has had a distribution configuration concept a while to make configuration between board more consistent and easier to integrate (see doc/README.distro). This patchset makes the various generation 3 boards use that concept.

Also include are two patch from upstream for PXE with aarch64 to make that type of netboot work properly