### PR TITLE
net: tftp: Fix incorrect tftp_next_ack on no OACK

### DIFF
--- a/net/tftp.c
+++ b/net/tftp.c
@@ -621,8 +621,10 @@ static void tftp_handler(uchar *pkt, unsigned dest, struct in_addr sip,
 		tftp_cur_block++;
 		tftp_cur_block %= TFTP_SEQUENCE_SIZE;
 
-		if (tftp_state == STATE_SEND_RRQ)
+		if (tftp_state == STATE_SEND_RRQ) {
 			debug("Server did not acknowledge any options!\n");
+			tftp_next_ack = tftp_windowsize;
+		}
 
 		if (tftp_state == STATE_SEND_RRQ || tftp_state == STATE_OACK ||
 		    tftp_state == STATE_RECV_WRQ) {


### PR DESCRIPTION
When the tftp server did not send any OACK, the tftp_next_ack variable
was not set to the correct value . As the server was transmitting
blocks we generated a lot of 'Received unexpected block: $n, expected
$n+1' error messages. Depending on the timeout setting the transfer
could still complete though.

Signed-off-by: Harm Berntsen <harm.berntsen@nedap.com>
CC: Ramon Fried <rfried.dev@gmail.com>
Reviewed-By: Ramon Fried <rfried.dev@gmail.com>

---

It appears that some old TFTP server do not support OPTIONS extension for the protocol, which causes problems in our case.
