### PR TITLE
net: rswtich: disable GWCA when removing driver

### DIFF
--- a/drivers/net/rswitch.c
+++ b/drivers/net/rswitch.c
@@ -1299,6 +1299,7 @@ err_mdio_alloc:
 static int rswitch_remove(struct udevice *dev)
 {
 	struct rswitch_priv *priv = dev_get_priv(dev);
+	int ret;
 
 	if (!priv->parallel_mode) {
 		clk_disable(&priv->rsw_clk);
@@ -1307,6 +1308,11 @@ static int rswitch_remove(struct udevice *dev)
 		free(priv->etha.phydev);
 		mdio_unregister(priv->etha.bus);
 	}
+
+	/* Turn off GWCA to make sure that there will be no new packets */
+	ret = rswitch_gwca_change_mode(priv, GWMC_OPC_DISABLE);
+	if (ret)
+		pr_err("Failed to disable GWCA: %d\n", ret);
 
 	unmap_physmem(priv->addr, MAP_NOCACHE);
 	unmap_physmem(priv->etha.serdes_addr, MAP_NOCACHE);


### PR DESCRIPTION
We need to disable GWCA for two reasons:

1. There may be packets coming to the device when U-Boot already transferred control to Linux, but Linux didn't had chance to re-configure GWCA. This may lead to memory corruption, as chains are already active.

2. Linux will not be able to switch GWCA to DISABLED state, because transition from OPERATION to DISABLED requires that all buffer pointers are released and all transactions are finished. But there are no one who can handle those operations, as U-Boot already exited and Linux is still trying to initialize R-Switch driver.

This fixes issue with DomD unable to initialize network in the parallel mode.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>